### PR TITLE
add support for hmc5883, add iobroker arguments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2019 Jürgen Schmid
+Copyright (c) 2023 Frank Löffler <frank.loeffler@uni-jena.de>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # qmc5883-gas-meter
-Read the gas consumption with a QMC5883 magnetometer via I2C or USB and send it to a MQTT broker like ioBroker
+Read the gas consumption with a QMC5883 or HMC5883 magnetometer via I2C or USB and send it to a MQTT broker like ioBroker
 
-HMC5883 Sensors are not easy to get, but QMC5883 are. Therfor here is a library to read the gas meter (i have a BK G4) and send the values to ioBroker (MQTT Adapter).
+HMC5883 Sensors are not easy to get, but QMC5883 are, and both work pretty similarly, although not quite the same. Therfore here is a library to read the gas meter (i have a BK G4) and send the values to ioBroker (MQTT Adapter).
 
 # Prerequisites
 - Gas counter with rotating magnet
-- Digital magnetometer QMC5883 (on breakout board)
+- Digital magnetometer QMC5883 or HMC5883 (on breakout board)
 - Raspberry/Arduino OR I2C/USB Adapter like me (CH341 USB)
 
 # qmc5883.py
@@ -22,7 +22,7 @@ HMC5883 Sensors are not easy to get, but QMC5883 are. Therfor here is a library 
 # Setup
 - Attach the magnetometer on your gas meter
 - setup the I2C connection [CH341 I2C/USB driver](https://github.com/gschorcht/i2c-ch341-usb)
-- configure constants of iobroker-client.py
+- use command line arguments of iobroker-client.py to configuration (./iobroker-client --help)
 - keep the program running and find the trigger_level for your setup
 
 # Grafana

--- a/iobroker-client.py
+++ b/iobroker-client.py
@@ -1,21 +1,52 @@
-import paho.mqtt.client as mqtt
+#!/usr/bin/env python3
+import argparse
 import os.path
 import time
+from datetime import datetime
 
-from qmc5883 import QMCClient
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                 description="publish data read from either a QMC5883 or HMC5883 sensor and publish them to an MQTT broker")
+parser.add_argument(      '--host',  type=str, required=True, default=argparse.SUPPRESS,
+                    help='mqtt host name or ip')
+parser.add_argument('-c', '--client', type=str, default="gasometer",
+                    help='mqtt client id string')
+parser.add_argument(      '--topic', type=str, default="gas/value",
+                    help='mqtt topic')
+parser.add_argument('-u', '--user',  type=str, default="mosquitto",
+                    help='mqtt user name')
+parser.add_argument(      '--pass',  type=str, required=True, default=argparse.SUPPRESS,
+                    help='mqtt passwort. The password is read from stdin if its value is "-".')
+parser.add_argument('-f', '--data-file', type=str, required=True, default=argparse.SUPPRESS,
+                    help='file to continuously write value to, to provide persistance across restarts')
+parser.add_argument('-i', '--initial-value', type=float, default=0.0,
+                    help='initial value to use if the file given to --data-file does not exist yet')
+parser.add_argument(      '--inc-value', type=float, default=0.01,
+                    help='increment by this value for each trigger event')
+parser.add_argument('-t', '--threshold', type=float, default=600.0,
+                    help='threshhold value of when to trigger counter')
+parser.add_argument('-s', '--sensor', choices=['qmc5883', 'hmc5883'], default='qmc5883',
+                    help='type of sensor')
+parser.add_argument(      '--debug-all-values', action='store_true',
+                    help='publish not only triggered events, but all x, y, z and B values: very noisy')
 
-# e.g. IObroker mqtt adapter:
-MQTT_HOST = "192.168.0.100"
-MQTT_TOPIC = "gas/value"
+args = vars(parser.parse_args())
 
-# current gas counter
-INITIAL_VALUE = 2650.36
+MQTT_HOST  = args['host']
+MQTT_TOPIC = args['topic']
+MQTT_USER  = args['user']
+if args['pass'] == '-':
+    MQTT_PASSWD = sys.stdin.readline().rstrip('\n')
+else:
+    MQTT_PASSWD = args['pass']
+if args['sensor'] == 'qmc5883':
+    from qmc5883 import QMCClient as Client
+else:
+    from qmc5883 import HMCClient as Client
+INITIAL_VALUE     = args['initial_value']
+DATA_FILE         = args['data_file']
+TRIGGER_THRESHOLD = args['threshold']
 
-# current counter will be persisted in
-DATA_FILE = "/var/lib/qmc5883-gas/value"
-
-# threshold of triggering the counter
-TRIGGER_THRESHOLD = 14000
+import paho.mqtt.client as mqtt
 
 def readValue():
     f = open(DATA_FILE, "r")
@@ -28,40 +59,77 @@ def writeValue(value):
     f = open(DATA_FILE, "w")
     f.write(str(value))
     f.close()
+    return
 
+
+client = mqtt.Client(client_id=args['client'], clean_session=False)
+client.username_pw_set(MQTT_USER, MQTT_PASSWD)
+client.connected_flag = False
+
+def on_connect(client, userdata, flags, rc):
+    print("ON CONNECT")
+    if rc == 0:
+        print("connected to broker")
+        client.connected_flag = True
+    else:
+        print("connected failed")
+def on_disconnect(client, userdata, rc):
+    print("disconnected from broker")
+    client.connected_flag = False
+
+client.on_connect = on_connect
+client.on_disconnect = on_disconnect
+
+print("CONNECT")
+client.loop_start()
+client.connect(MQTT_HOST)
+time.sleep(2)
 
 def publish(value):
-    print MQTT_TOPIC + " " + str(INITIAL_VALUE)
-    client.publish(MQTT_TOPIC, INITIAL_VALUE)
-
+    if not client.connected_flag:
+        print("Could not publish value because connection was down, restarting connection instead.")
+        client.loop_start()
+        try:
+          client.connect(MQTT_HOST)
+        except Exception as e:
+          print("Unable to connect right now. Retrying later.")
+          print(f"  Reason: {e}")
+          pass
+    # do not wait for connection if it still has to be established: we might loose
+    # the counter steps that way, rather decide to not send this one increase but
+    # the correct number next time instead
+    else:
+        print(MQTT_TOPIC + f' {{"time":"{datetime.now().timestamp()}","value": {round(value, 2)}}}')
+        client.publish(MQTT_TOPIC, f'{{"time":"{datetime.now().timestamp()}","value": {round(value, 2)}}}', qos=0)
+    #client.disconnect()
 
 if not os.path.exists(DATA_FILE):
-    print "Write initial value to data file: " + str(INITIAL_VALUE)
+    print("Write initial value to data file: " + str(INITIAL_VALUE))
     if not os.path.exists(os.path.dirname(DATA_FILE)):
         os.makedirs(os.path.dirname(DATA_FILE))
     f = open(DATA_FILE, "w+")
     f.write(str(INITIAL_VALUE))
+    value = INITIAL_VALUE
     f.close()
 else:
-    INITIAL_VALUE = readValue()
+    value = readValue()
 
-client = mqtt.Client()
-print "Connecting to mqtt broker"
-client.connect(MQTT_HOST)
-publish(INITIAL_VALUE)
-print "Connecting to gas meter"
-q = QMCClient(5, TRIGGER_THRESHOLD)
+publish(value)
+print("Connecting to gas meter")
+q = Client(1, TRIGGER_THRESHOLD)
 q.init()
 
-while 1 == 1:
+while True:
     data = q.read()
-    print data
-    client.publish("gas/x", data['x'])
-    client.publish("gas/y", data['y'])
-    client.publish("gas/z", data['z'])
-    client.publish("gas/B", data['b'])
-    if(data['triggered'] == 1):
-        INITIAL_VALUE += 0.01
-        writeValue(INITIAL_VALUE)
-        publish(INITIAL_VALUE)
-    time.sleep(1)
+    print(data)
+    if args['debug_all_values']:
+        client.publish("gas/x", data['x'])
+        client.publish("gas/y", data['y'])
+        client.publish("gas/z", data['z'])
+        client.publish("gas/B", data['b'])
+    if data['triggered'] == 1:
+        value += args['inc_value']
+        writeValue(value)
+        publish(value)
+    else:
+        time.sleep(0.5)

--- a/qmc5883.py
+++ b/qmc5883.py
@@ -3,18 +3,124 @@ import time
 
 import smbus
 
-
-class QMCClient:
-    # Register numbers
-    X_LSB = 0x00
-    CONFIG = 0x09
-    STATUS = 0x06
-    RESET = 0x0B
+# general class for functionality common to QMC and HMC
+class XMCClient:
+    # values that should be overwritten by child classes
+    name          = "XMC5883"
+    address       = 0x1e
+    trigger_hyst  = 100
+    big_endian    = False
+    OFFSET_X      = 0
+    OFFSET_Y      = 2
+    OFFSET_Z      = 4
 
     # Bit values for the STATUS register
     STATUS_DRDY = 1
-    STATUS_OVL = 2
-    STATUS_DOR = 4
+
+    # class-internal state variables
+    trigger_state = 0
+    old_state     = 0
+    just_started  = True
+
+    def __init__(self, i2c_channel, trigger_level):
+        self.channel = i2c_channel
+        self.trigger_level = trigger_level
+        print(f"Init {self.name} @ i2c-{self.channel}")
+        self.bus = smbus.SMBus(self.channel)
+
+    def write(self, reg, val):
+        self.bus.write_byte_data(self.address, reg, val)
+
+    # read a single register
+    def __read__(self, reg):
+        return self.bus.read_byte_data(self.address, reg)
+
+    # read a block: for use with the data registers which all should be read
+    def __read_block__(self):
+        # This will block until we can get data, in order to skip occational
+        # i2c hickups. Ideally, this would include a timeout, althought all
+        # we could do then would be to quit.
+        while True:
+            try:
+                return self.bus.read_i2c_block_data(self.address, 0x00)
+            except OSError as e:
+                print(e)
+                time.sleep(.1)
+                continue
+
+    # Convert val to signed value
+    def twos_complement(self, val, len):
+        if (val & (1 << len - 1)):
+            val = val - (1 << len)
+        return val
+
+    # Convert two bytes from data starting at offset to signed word
+    def convert_sw(self, data, offset):
+        if self.big_endian:
+            return self.twos_complement(data[offset    ] << 8 |
+                                        data[offset + 1]       , 16)
+        else:
+            return self.twos_complement(data[offset    ]      |
+                                        data[offset + 1] << 8  , 16)
+
+    def ready(self):
+        status = self.__read__(self.STATUS)
+        # print("ready: " + str(status))
+        return status & self.STATUS_DRDY
+
+    def init(self):
+        # initialization has to happen in child classes due to too many
+        # differences between QMC and HMC
+        pass
+
+    def extract_data(self, raw):
+        # extract x,y,z values of magnetic induction from raw data
+        data = dict()
+        data['x'] = self.convert_sw(raw, self.OFFSET_X)
+        data['y'] = self.convert_sw(raw, self.OFFSET_Y)
+        data['z'] = self.convert_sw(raw, self.OFFSET_Z)
+        # calculate value of B independent of direction
+        data['b'] = math.sqrt(
+            float(data['x'] * data['x']) +
+            float(data['y'] * data['y']) +
+            float(data['z'] * data['z']))
+        return data
+
+    def _read(self):
+        raise(NotImplementedError("_read() has to be implemented by child classes."))
+
+    def read(self):
+        self.old_state = self.trigger_state
+        data = self._read()
+        data['triggered'] = 0
+
+        # print(data['b'])
+        if   data['b'] > self.trigger_level + self.trigger_hyst:
+            self.trigger_state = 1
+        elif data['b'] < self.trigger_level - self.trigger_hyst:
+            self.trigger_state = 0
+
+        # avoid triggers because we just started
+        if self.just_started:
+            self.just_started = False
+            self.old_state = self.trigger_state
+
+        if self.old_state == 0 and self.trigger_state == 1:
+            data['triggered'] = 1
+
+        return data
+
+class QMCClient(XMCClient):
+    # Register numbers
+    X_LSB  = 0x00
+    STATUS = 0x06
+    CONFIG = 0x09
+    RESET  = 0x0B
+
+    # Bit values for the STATUS register
+    STATUS_DRDY = 1
+    STATUS_OVL  = 2
+    STATUS_DOR  = 4
 
     # Oversampling values for the CONFIG register
     CONFIG_OS512 = 0b00000000
@@ -29,35 +135,16 @@ class QMCClient:
     # Mode values for the CONFIG register
     CONFIG_CONTINUOUS = 0b00000001
 
-    address = 0x0D
-    trigger_hyst = 2000
-    trigger_state = 0
-    old_state = 0
-
-    def __init__(self, i2c_channel, trigger_level):
-        self.channel = i2c_channel
-        self.trigger_level = trigger_level
-        print "Init QMC5883 @ i2c-" + str(self.channel)
-        self.bus = smbus.SMBus(self.channel)
-
-    def write(self, reg, val):
-        self.bus.write_byte_data(self.address, reg, val)
-
-    def __read__(self, reg):
-        return self.bus.read_byte_data(self.address, reg)
-
-    # Convert val to signed value
-    def twos_complement(self, val, len):
-        if (val & (1 << len - 1)):
-            val = val - (1 << len)
-        return val
-
-    # Convert two bytes from data starting at offset to signed word
-    def convert_sw(self, data, offset):
-        return self.twos_complement(data[offset] | data[offset + 1] << 8, 16)
+    # overwriting parent class variables
+    name          = "QMC5883"
+    address       = 0x1d
+    trigger_hyst  = 2000
+    big_endian    = False
+    OFFSET_X      = 0
+    OFFSET_Y      = 2
+    OFFSET_Z      = 4
 
     def init(self):
-
         # reset device
         self.write(self.RESET, 0x01)
         time.sleep(1)
@@ -67,46 +154,84 @@ class QMCClient:
                    | self.CONFIG_8GAUSS
                    | self.CONFIG_OS512)
 
-    def ready(self):
-        status = self.__read__(self.STATUS)
-        print "ready: " + str(status)
-        return status & self.STATUS_DRDY
-
-    def __read(self):
-        # self.ready()
+    def _read(self):
         while not self.ready():
             time.sleep(0.1)
-            print "waiting for DRDY"
+            print("waiting for DRDY")
 
         # read data from QMC5883
         raw = []
         for i in range(0, 6):
             raw.append(self.__read__(i))
-
-        # get x,y,z values of magnetic induction
-        data = dict()
-        data['x'] = self.convert_sw(raw, 0)  # x
-        data['y'] = self.convert_sw(raw, 2)  # y
-        data['z'] = self.convert_sw(raw, 4)  # z
-        data['b'] = math.sqrt(
-            float(data['x'] * data['x']) +
-            float(data['y'] * data['y']) +
-            float(data['z'] * data['z']))
-
+        data = self.extract_data(raw)
         return data
 
-    def read(self):
+class HMCClient(XMCClient):
+    # Register numbers
+    CONFIGA = 0x00
+    CONFIGB = 0x01
+    CONFIGM = 0x02
+    DATA    = 0x03
+    STATUS  = 0x09
 
-        self.old_state = self.trigger_state
-        data = self.__read()
-        data['triggered'] = 0
+    # Bit values for the STATUS register
+    STATUS_DRDY = 1
 
-        if data['b'] > self.trigger_level + self.trigger_hyst:
-            self.trigger_state = 1
-        elif data['b'] < self.trigger_level - self.trigger_hyst:
-            self.trigger_state = 0
+    # Range values for the CONFIG register
+    CONFIG_GAUSS = {
+      0.88: {"reg": 0b000, "gain": 1370},
+      1.3 : {"reg": 0b001, "gain": 1090},
+      1.9 : {"reg": 0b010, "gain":  820},
+      2.5 : {"reg": 0b011, "gain":  660},
+      4.0 : {"reg": 0b100, "gain":  440},
+      4.7 : {"reg": 0b101, "gain":  390},
+      5.6 : {"reg": 0b110, "gain":  330},
+      8.1 : {"reg": 0b111, "gain":  230},
+      }
 
-        if self.old_state == 0 and self.trigger_state == 1:
-            data['triggered'] = 1
+    # Rate values for the CONFIG register
+    CONFIG_HZ = {
+       0.75: 0b000,
+       1.5 : 0b001,
+       3   : 0b010,
+       7.5 : 0b011,
+      15   : 0b100,
+      30   : 0b101,
+      75   : 0b110,
+    }
 
+    # Numbers of samples averaged
+    CONFIG_AVG = {
+      1: 0b00,
+      2: 0b01,
+      4: 0b10,
+      8: 0b11,
+    }
+
+    # Mode values for the CONFIG register
+    CONFIG_CONTINUOUS = 0b00;
+
+    # overwriting parent class variables
+    name          = "HMC5883"
+    address       = 0x1e
+    trigger_hyst  = 100
+    big_endian    = True
+    OFFSET_X      = DATA + 0
+    OFFSET_Y      = DATA + 4
+    OFFSET_Z      = DATA + 2
+
+    def init(self):
+        # configure device
+        self.write(self.CONFIGA, self.CONFIG_AVG[8] << 5 |
+                                 self.CONFIG_HZ[15] << 2)
+        self.write(self.CONFIGB, self.CONFIG_GAUSS[8.1]["reg"] << 5)
+        self.write(self.CONFIGM, self.CONFIG_CONTINUOUS)
+        while not self.ready():
+            time.sleep(0.1)
+            print("waiting for DRDY")
+
+    def _read(self):
+        # read data from HMC5883
+        raw = self.__read_block__()
+        data = self.extract_data(raw)
         return data


### PR DESCRIPTION
The two major additions in this patch (sorry for this being in one) are:

1. Add support for HMC5883 besides QMC5883. Those are different, but similar enough chips to warrant a base class that implements the functionality common to both (which is most), and leaves the code that is different to separate child classes. This is mainly:
   - chip initialization
   - readout of raw measurement values
2. Use command line arguments for configureable values of the iobroker. Up to this change, those had to be edited by hand inside the script. Now the script does not have the be edited anymore. Instead, everything that I thought could possibly need configuration now has a command line argument, with what I hope are reasonable defaults where those made sense.

Smaller changes include
- python3 compatibilty
- also announce current time to mqtt, not only the raw gas value
- try to reconnect if connection was lost, instead of aborting
- if broker cannot make connection (even initially), do not abort, but keep going and keep trying